### PR TITLE
Added force to controller register action to allow blueprint overwrite

### DIFF
--- a/libs/controllers.js
+++ b/libs/controllers.js
@@ -46,7 +46,7 @@ module.exports = function (sails, dir, cb) {
           }
 
           // register the action
-          sails.registerAction(controller, controller.identity);
+          sails.registerAction(controller, controller.identity, true);
 
         } else  if (controller.globalId && controller.identity) {
           // this is a traditional controller
@@ -69,7 +69,7 @@ module.exports = function (sails, dir, cb) {
             // sails.log.verbose('Micro-Apps: register controller action: ', action, ' actionId: ', actionId);
 
             // register the action
-            sails.registerAction(action, actionId);
+            sails.registerAction(action, actionId, true);
           });
         } else {
           // throw error, this is not a controller or standalone action


### PR DESCRIPTION
Without the force flag, the injection results in

> The action `user/create` could not be registered because it conflicts with a previously-registered action

To overwrite blueprint actions, the controller injection has to be done after the blueprints hook has been loaded:

```
module.exports = function (sails) {
    var loader = require('sails-util-micro-apps')(sails); // infere the root micro-app dir automatically

    // Automatically inject hooks, policies and configs
    loader.configure({
        config: __dirname + '/config',
        policies: __dirname + '/api/policies'
    });

    /*
        OR if you want to set a custom path :

        loader.configure({
            hooks: __dirname,// custom Path to hooks, usually the root of the micro-app
            policies: __dirname + '/api/policies',// custom Path to policies
            config: __dirname + '/config'// custom Path to config
        });
     */

    // ... do other stuff

    return {
        initialize: function (next) {
            /*
                Automatically inject:
                 - models under hook's ./api/models
                 - controllers under hook's ./api/controllers
                 - helpers under hook's ./api/helpers
                 - services under hook's ./api/services
            */
            let error;
            loader.inject({
                models: __dirname + '/api/models', // Path to the models to inject, it must be absolute
                helpers: __dirname + '/api/helpers', // Path to the helpers to inject, it must be absolute
                
            }, function (err) {
                if(err)
                 error = err;
            });

            sails.on('hook:blueprints:loaded', function () {
                loader.inject({
                    controllers: __dirname + '/api/controllers'
                }, function(err) {
                    if(err)
                        error = err;
                    return next(error);
                });
                

            });
        }
    };
}
```